### PR TITLE
Fix: httr2 regression

### DIFF
--- a/R/request-helpers.R
+++ b/R/request-helpers.R
@@ -23,6 +23,7 @@ db_request <- function(endpoint, method, version = NULL, body = NULL, host, toke
     httr2::req_method(method)
 
   if (!is.null(body)) {
+    body <- base::Filter(length, body)
     req <- req %>%
       httr2::req_body_json(body, ...)
   }


### PR DESCRIPTION
 - addressed a regression due to changes in {httr2} where empty elements of request body were not removed