### PR TITLE
Add rmarkdown import

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -42,8 +42,8 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,9 +26,9 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
@@ -38,7 +38,7 @@ jobs:
           git add man/\* NAMESPACE
           git commit -m 'Document'
 
-      - uses: r-lib/actions/pr-push@v1
+      - uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,11 +51,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/pr-fetch@v1
+      - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
 
       - name: Install dependencies
         run: Rscript -e 'install.packages("styler")'
@@ -70,6 +70,6 @@ jobs:
           git add \*.R
           git commit -m 'Style'
 
-      - uses: r-lib/actions/pr-push@v1
+      - uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: covr
 

--- a/R/execution-context.R
+++ b/R/execution-context.R
@@ -142,25 +142,29 @@ db_context_command_run <- function(cluster_id,
     stop("Must `command` OR `command_file` not both.")
   }
 
-  body <- list(
-    clusterId = cluster_id,
-    contextId = context_id,
-    language = language,
-    command = command,
-    commandFile = command_file,
-    options = options
-  )
+  if (!is.null(command_file)) {
+    command <- curl::form_file(command_file)
+  }
 
   req <- db_request(
     endpoint = "commands/execute",
     method = "POST",
     version = "1.2",
-    body = body,
+    body = NULL,
     host = host,
     token = token
   )
 
-  if (perform_request) {
+  req <- httr2::req_body_multipart(
+    req,
+    clusterId = cluster_id,
+    contextId = context_id,
+    language = language,
+    command = command,
+    options = options
+  )
+
+    if (perform_request) {
     db_perform_request(req)
   } else {
     req

--- a/R/workspaces.R
+++ b/R/workspaces.R
@@ -47,7 +47,8 @@ db_workspace_delete <- function(path, recursive = FALSE,
 
 #' Export Notebook or Directory (Workspaces)
 #'
-#' @param format One of `SOURCE`, `HTML`, `JUPYTER`, `DBC`. Default is `SOURCE`.
+#' @param format One of `SOURCE`, `HTML`, `JUPYTER`, `DBC`, `R_MARKDOWN`.
+#' Default is `SOURCE`.
 #' @inheritParams auth_params
 #' @inheritParams db_workspace_delete
 #' @inheritParams db_sql_warehouse_create
@@ -70,7 +71,7 @@ db_workspace_delete <- function(path, recursive = FALSE,
 #' @return base64 encoded string
 #' @export
 db_workspace_export <- function(path,
-                                format = c("SOURCE", "HTML", "JUPYTER", "DBC"),
+                                format = c("SOURCE", "HTML", "JUPYTER", "DBC", "R_MARKDOWN"),
                                 host = db_host(), token = db_token(),
                                 perform_request = TRUE) {
 
@@ -173,7 +174,7 @@ db_workspace_get_status <- function(path,
 db_workspace_import <- function(path,
                                 file = NULL,
                                 content = NULL,
-                                format = c("SOURCE", "HTML", "JUPYTER", "DBC"),
+                                format = c("SOURCE", "HTML", "JUPYTER", "DBC", "R_MARKDOWN"),
                                 language = NULL,
                                 overwrite = FALSE,
                                 host = db_host(), token = db_token(),

--- a/man/db_workspace_export.Rd
+++ b/man/db_workspace_export.Rd
@@ -6,7 +6,7 @@
 \usage{
 db_workspace_export(
   path,
-  format = c("SOURCE", "HTML", "JUPYTER", "DBC"),
+  format = c("SOURCE", "HTML", "JUPYTER", "DBC", "R_MARKDOWN"),
   host = db_host(),
   token = db_token(),
   perform_request = TRUE
@@ -15,7 +15,8 @@ db_workspace_export(
 \arguments{
 \item{path}{Absolute path of the notebook or directory.}
 
-\item{format}{One of \code{SOURCE}, \code{HTML}, \code{JUPYTER}, \code{DBC}. Default is \code{SOURCE}.}
+\item{format}{One of \code{SOURCE}, \code{HTML}, \code{JUPYTER}, \code{DBC}, \code{R_MARKDOWN}.
+Default is \code{SOURCE}.}
 
 \item{host}{Databricks workspace URL, defaults to calling \code{\link[=db_host]{db_host()}}.}
 

--- a/man/db_workspace_import.Rd
+++ b/man/db_workspace_import.Rd
@@ -8,7 +8,7 @@ db_workspace_import(
   path,
   file = NULL,
   content = NULL,
-  format = c("SOURCE", "HTML", "JUPYTER", "DBC"),
+  format = c("SOURCE", "HTML", "JUPYTER", "DBC", "R_MARKDOWN"),
   language = NULL,
   overwrite = FALSE,
   host = db_host(),
@@ -24,7 +24,8 @@ db_workspace_import(
 \item{content}{Content to upload, this will be base64-encoded and has a limit
 of 10MB.}
 
-\item{format}{One of \code{SOURCE}, \code{HTML}, \code{JUPYTER}, \code{DBC}. Default is \code{SOURCE}.}
+\item{format}{One of \code{SOURCE}, \code{HTML}, \code{JUPYTER}, \code{DBC}, \code{R_MARKDOWN}.
+Default is \code{SOURCE}.}
 
 \item{language}{One of \code{R}, \code{PYTHON}, \code{SCALA}, \code{SQL}. Required when \code{format}
 is \code{SOURCE} otherwise ignored.}


### PR DESCRIPTION
Supporting import of R Markdown into Databricks.

Currently this is supported in with direct imports via the Databricks web UI.
This change exposes the same behaviour - currently undocumented.
