### PR TITLE
Add cluster policy support + fixes

### DIFF
--- a/R/clusters.R
+++ b/R/clusters.R
@@ -69,6 +69,7 @@
 #' @param enable_local_disk_encryption Boolean (Default: `TRUE`), whether
 #' encryption of disks locally attached to the cluster is enabled.
 #' @param docker_image Instance of [docker_image()].
+#' @param policy_id String, ID of a cluster policy.
 #' @inheritParams auth_params
 #' @inheritParams db_sql_warehouse_create
 #'
@@ -113,6 +114,7 @@ db_cluster_create <- function(name,
                               apply_policy_default_values = TRUE,
                               enable_local_disk_encryption = TRUE,
                               docker_image = NULL,
+                              policy_id = NULL,
                               host = db_host(), token = db_token(),
                               perform_request = TRUE) {
 
@@ -140,7 +142,8 @@ db_cluster_create <- function(name,
     idempotency_token = idempotency_token,
     apply_policy_default_values = apply_policy_default_values,
     enable_local_disk_encryption = enable_local_disk_encryption,
-    docker_image = docker_image
+    docker_image = docker_image,
+    policy_id = policy_id
   )
 
   if (is.null(num_workers)) {
@@ -223,6 +226,7 @@ db_cluster_edit <- function(cluster_id,
                             apply_policy_default_values = NULL,
                             enable_local_disk_encryption = NULL,
                             docker_image = NULL,
+                            policy_id = NULL,
                             host = db_host(), token = db_token(),
                             perform_request = TRUE) {
 
@@ -255,7 +259,8 @@ db_cluster_edit <- function(cluster_id,
     idempotency_token = idempotency_token,
     apply_policy_default_values = apply_policy_default_values,
     enable_local_disk_encryption = enable_local_disk_encryption,
-    docker_image = docker_image
+    docker_image = docker_image,
+    policy_id = policy_id
   )
 
   if (!(is.null(num_workers) && is.null(autoscale))) {

--- a/R/execution-context.R
+++ b/R/execution-context.R
@@ -142,25 +142,29 @@ db_context_command_run <- function(cluster_id,
     stop("Must `command` OR `command_file` not both.")
   }
 
-  body <- list(
-    clusterId = cluster_id,
-    contextId = context_id,
-    language = language,
-    command = command,
-    commandFile = command_file,
-    options = options
-  )
+  if (!is.null(command_file)) {
+    command <- curl::form_file(command_file)
+  }
 
   req <- db_request(
     endpoint = "commands/execute",
     method = "POST",
     version = "1.2",
-    body = body,
+    body = NULL,
     host = host,
     token = token
   )
 
-  if (perform_request) {
+  req <- httr2::req_body_multipart(
+    req,
+    clusterId = cluster_id,
+    contextId = context_id,
+    language = language,
+    command = command,
+    options = options
+  )
+
+    if (perform_request) {
     db_perform_request(req)
   } else {
     req

--- a/man/db_cluster_create.Rd
+++ b/man/db_cluster_create.Rd
@@ -26,6 +26,7 @@ db_cluster_create(
   apply_policy_default_values = TRUE,
   enable_local_disk_encryption = TRUE,
   docker_image = NULL,
+  policy_id = NULL,
   host = db_host(),
   token = db_token(),
   perform_request = TRUE
@@ -117,6 +118,8 @@ policy default values for missing cluster attributes.}
 encryption of disks locally attached to the cluster is enabled.}
 
 \item{docker_image}{Instance of \code{\link[=docker_image]{docker_image()}}.}
+
+\item{policy_id}{String, ID of a cluster policy.}
 
 \item{host}{Databricks workspace URL, defaults to calling \code{\link[=db_host]{db_host()}}.}
 

--- a/man/db_cluster_edit.Rd
+++ b/man/db_cluster_edit.Rd
@@ -27,6 +27,7 @@ db_cluster_edit(
   apply_policy_default_values = NULL,
   enable_local_disk_encryption = NULL,
   docker_image = NULL,
+  policy_id = NULL,
   host = db_host(),
   token = db_token(),
   perform_request = TRUE
@@ -120,6 +121,8 @@ policy default values for missing cluster attributes.}
 encryption of disks locally attached to the cluster is enabled.}
 
 \item{docker_image}{Instance of \code{\link[=docker_image]{docker_image()}}.}
+
+\item{policy_id}{String, ID of a cluster policy.}
 
 \item{host}{Databricks workspace URL, defaults to calling \code{\link[=db_host]{db_host()}}.}
 


### PR DESCRIPTION
Was an oversight to exclude `policy_id` from respective `db_cluster_*` funcitons.

PR also includes fixes to all execution context functions to run files.