### PR TITLE
knitr engine improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: brickster
 Title: R interface to Databricks REST 2.0 APIs
-Version: 0.1.1
+Version: 0.2.0
 Authors@R: 
   c(
     person(given = "Zac",
@@ -13,7 +13,7 @@ Authors@R:
            email = "rafi.kurlansik@databricks.com"),
     person("Databricks", role = c("cph", "fnd"))
   )
-Description: R interface to Databricks REST 2.0 APIs.
+Description: Toolkit to work with Databricks from R
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/knitr-engines.R
+++ b/R/knitr-engines.R
@@ -49,13 +49,21 @@ db_engine_scala <- function(options) {
   db_engine_template(options, language = "scala")
 }
 
-
 #' Databricks knitr Engine (SQL)
 #'
 #' @inheritParams db_engine_template
 #' @noRd
 db_engine_sql <- function(options) {
   db_engine_template(options, language = "sql")
+}
+
+#' Databricks knitr Engine (Shell)
+#'
+#' @inheritParams db_engine_template
+#' @noRd
+db_engine_sh <- function(options) {
+  options$code <- paste0("%%sh\n", options$code)
+  db_engine_template(options, language = "python")
 }
 
 #' Clean Command Output From Execution Context

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,9 +2,15 @@
   if (requireNamespace("knitr", quietly = TRUE)) {
     knitr::knit_engines$set(
       databricks_r = db_engine_r,
+      db_r = db_engine_r,
       databricks_py = db_engine_py,
+      db_py = db_engine_py,
       databricks_scala = db_engine_scala,
-      databricks_sql = db_engine_sql
+      db_scala = db_engine_scala,
+      databricks_sql = db_engine_sql,
+      db_sql = db_engine_sql,
+      databricks_sh = db_engine_sh,
+      db_sh = db_engine_sh
     )
   }
 }


### PR DESCRIPTION
Can now use `%sh` magic in rmarkdown:

This is achieved thanks to `%%sh` in a python context.

```r
    ```{databricks_sh}
    ls -la /
    ``` 
```

Additionally can use new `db_{r/py/scala/sh}` shorthand
```r
    ```{db_r}
    library(sparklyr)
    sc <- spark_connect(method = "databricks")
    ``` 
```